### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/gsw/backend/views.py
+++ b/gsw/backend/views.py
@@ -59,7 +59,7 @@ class GSWDefaultViewSet(CacheResponseAndETAGMixin, viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         assert self.model_class is not None, "You need to override model_class"
-        serializer_name = "%sSerializer" % self.model_class.__name__
+        serializer_name = "{0!s}Serializer".format(self.model_class.__name__)
         return globals()[serializer_name]
 
 

--- a/gsw/sync_data/emergency_numbers/sync_emergency_numbers.py
+++ b/gsw/sync_data/emergency_numbers/sync_emergency_numbers.py
@@ -13,7 +13,7 @@ def clean_wordpress_content(content):
 langs = ["en","de","fr","ar"]
 questions = {}
 for lang in langs:
-	faq_req = requests.get("http://dev-admin.germany-says-welcome.de/wp-json/wp/v2/emergency?lang=%s"%lang)
+	faq_req = requests.get("http://dev-admin.germany-says-welcome.de/wp-json/wp/v2/emergency?lang={0!s}".format(lang))
 	data = faq_req.json()
 	for question in data:
 		if question['original_id'] is not None:

--- a/gsw/sync_data/erstaufnameeinrichtungen/erstaufnameeinrichtungen.py
+++ b/gsw/sync_data/erstaufnameeinrichtungen/erstaufnameeinrichtungen.py
@@ -31,7 +31,7 @@ with open("erstaufnameeinrichtungen.csv", encoding='latin-1') as csvfile:
             if 'county' in data['address'] and data['address']['county'] in gemeinden:
                 county = gemeinden[data['address']['county']]
             else:
-                print("No county id for %s"%row[0])
+                print("No county id for {0!s}".format(row[0]))
                 csvwriter.writerow(row)
                 county = "00000000"
             poi = {"translations":{}}

--- a/gsw/sync_data/faq_cats/sync_faq_categories.py
+++ b/gsw/sync_data/faq_cats/sync_faq_categories.py
@@ -9,7 +9,7 @@ import filecmp
 langs = ["en","de","fr","ar"]
 faq_categories = {}
 for lang in langs:
-    faq_req = requests.get("http://dev-admin.germany-says-welcome.de/?__api=1&type=faq_categories&lang=%s"%lang)
+    faq_req = requests.get("http://dev-admin.germany-says-welcome.de/?__api=1&type=faq_categories&lang={0!s}".format(lang))
     data = faq_req.json()
     for cat in data:
         if cat['original_id'] is not None:
@@ -39,9 +39,9 @@ for cat_id in faq_categories:
     if faq_categories[cat_id]['image_url']:
         image = requests.get(faq_categories[cat_id]['image_url'])
         image_name = os.path.basename(faq_categories[cat_id]['image_url'])
-        with open("/tmp/%s"%image_name, "wb") as f:
+        with open("/tmp/{0!s}".format(image_name), "wb") as f:
             f.write(image.content)
-        reopen = open("/tmp/%s"%image_name, "rb")
+        reopen = open("/tmp/{0!s}".format(image_name), "rb")
         if entry.image != "":
             old_image = entry.image.open()
         if reopen != None:

--- a/gsw/sync_data/faq_items/sync_faq_items.py
+++ b/gsw/sync_data/faq_items/sync_faq_items.py
@@ -13,7 +13,7 @@ def clean_wordpress_content(content):
 langs = ["en","de","fr","ar"]
 questions = {}
 for lang in langs:
-	faq_req = requests.get("http://dev-admin.germany-says-welcome.de/?__api=1&type=faq&lang=%s"%lang)
+	faq_req = requests.get("http://dev-admin.germany-says-welcome.de/?__api=1&type=faq&lang={0!s}".format(lang))
 	data = faq_req.json()
 	for question in data:
 		if question['original_id'] is not None:

--- a/gsw/sync_data/kitas/kitas.py
+++ b/gsw/sync_data/kitas/kitas.py
@@ -40,7 +40,7 @@ with open("kitas.csv", encoding='latin-1') as csvfile:
             if 'county' in data['address'] and data['address']['county'] in gemeinden:
                 county = gemeinden[data['address']['county']]
             else:
-                print("No county id for %s"%row[0])
+                print("No county id for {0!s}".format(row[0]))
                 csvwriter.writerow(row)
                 county = "00000000"
             poi = {"translations":{}}


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:socialc0de:germany-says-welcome-backend?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:socialc0de:germany-says-welcome-backend?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
